### PR TITLE
UP-1745 - Exposes `makeTypedMockFn`

### DIFF
--- a/js-test-utils/package.json
+++ b/js-test-utils/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/35up/js-test-utils#readme",
   "dependencies": {
-    "lit-html": "^1.3.0"
+    "sinon": "^9.0.3"
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",
@@ -41,7 +41,6 @@
     "eslint": "^7.21.0",
     "jest": "^26.0.13",
     "regenerator-runtime": "^0.13.7",
-    "sinon": "^9.0.3",
     "sinon-chai": "^3.5.0",
     "ts-jest": "^26.0.13",
     "typescript": "^4.0.2"

--- a/js-test-utils/src/index.ts
+++ b/js-test-utils/src/index.ts
@@ -1,2 +1,3 @@
 export { flushPromises } from './flush-promises';
 export { delay, delayResolve } from './delay';
+export { makeTypedMockFn } from './make-typed-mock-fn';

--- a/js-test-utils/src/make-typed-mock-fn.ts
+++ b/js-test-utils/src/make-typed-mock-fn.ts
@@ -1,0 +1,7 @@
+import { SinonStub } from 'sinon';
+
+
+// eslint-disable-next-line
+export const makeTypedMockFn = <T extends (...args: any[]) => any>(fn: T) => (
+  fn as unknown as SinonStub<Parameters<typeof fn>, ReturnType<typeof fn>>
+);


### PR DESCRIPTION
Maybe rename it to `makeTypedStub` or `makeTypedStubFn`? As we are using sinon (avoiding confusing with jest.Mock)