### PR TITLE
UP-2573 - Reduces iterations

### DIFF
--- a/tslib-test-utils/src/fuzz.ts
+++ b/tslib-test-utils/src/fuzz.ts
@@ -11,7 +11,7 @@ export function fuzz<T>(
   iterable: () => Iterable<T>,
   description: string,
   fn: (arg: T) => (Promise<void> | void),
-  samples = 30,
+  samples = 7,
 ): void {
   for (const item of take(iterable, samples)()) {
   // eslint-disable-next-line prefer-arrow-callback,func-names
@@ -31,7 +31,7 @@ export function fuzzDescribe<T>(
   iterable: () => Iterable<T>,
   description: string,
   fn: (arg: T) => void,
-  samples = 30,
+  samples = 7,
 ): void {
   for (const item of take(iterable, samples)()) {
   // eslint-disable-next-line prefer-arrow-callback,func-names


### PR DESCRIPTION
The current approach is susceptible to consume too much memory.
There is an approach that is less memory intensive, but you loose the beforeEach and afterEach hooks